### PR TITLE
add .* to run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win or python_impl == 'pypy']
-  number: 4
+  number: 5
   force_use_keys:
     # separate builds for each Python
     # this duplicates libbasix outputs, but results in faster builds
@@ -85,7 +85,7 @@ outputs:
         - {{ pin_subpackage('fenics-basix', exact=True) }}
       run_constrained:
         - pybind11-abi {{ pybind11_abi }}
-        - {{ cxx_compiler }} {{ cxx_compiler_version }}
+        - {{ cxx_compiler }} {{ cxx_compiler_version }}.*
 
     test:
       commands:


### PR DESCRIPTION
seems to be doing exact pinning in run_constrained, which I don't think is right, but the run_constrained is blocking clangxx 15.0.7.*, but allowing clangxx 15.0.0.
