### PR TITLE
set host platform tag on cross-linux

### DIFF
--- a/recipe/build-basix-py.sh
+++ b/recipe/build-basix-py.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -ex
 cd python
+
+# cross-compiled linux produces wrong wheel tags
+# causing pip check to fail
+if [[ "${target_platform}" == "linux-aarch64" ]]; then
+  export _PYTHON_HOST_PLATFORM=linux_aarch64
+elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
+  export _PYTHON_HOST_PLATFORM=linux_ppc64le
+fi
+
 $PYTHON -m pip install --no-build-isolation --no-deps -vv .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   skip: true  # [python_impl == 'pypy' or py<39]
-  number: 0
+  number: 1
   force_use_keys:
     # separate builds for each Python
     # this duplicates libbasix outputs, but results in faster builds
@@ -88,6 +88,7 @@ outputs:
       imports:
         - basix
       commands:
+        - pip check
         - pytest -v test/test_create.py
 
   - name: fenics-basix-nanobind-abi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,6 +76,7 @@ outputs:
         - fenics-basix-nanobind-abi =={{ abi_version }}
     test:
       requires:
+        - pip
         - pytest
         - pytest-xdist
         # make sure the abi constraint is on an installable package


### PR DESCRIPTION
it's missing the `linux_` for some reason, resulting in wheel tag `cp312-cp312-aarch64` instead of `cp312-cp312-linux_aarch64`, leading to

```
fenics-basix 0.9.0 is not supported on this platform
```

and add `pip check` to make sure this is fixed