### PR TITLE
rebuild with older nanobind abi scheme

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -20,8 +20,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -22,8 +22,8 @@ liblapack:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -12,8 +12,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -12,8 +12,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -12,8 +12,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -12,8 +12,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -12,8 +12,8 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
-nanobind_abi:
-- '15'
+nanobind:
+- '2.8'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,6 @@
 # need a pinning for this to get it into context variables
 # we won't get notified when there is a new abi version
 nanobind_abi:
-  - 15
+  - 16
+nanobind:
+  - "2.8"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,8 @@ context:
   # cxx_compiler_version not specified on Windows
   # extract from cxx_compiler
   cxx_compiler_version: ${{ cxx_compiler_version | default(cxx_compiler | replace("vs", "")) }}
-  abi_version: 1.${{ nanobind_abi }}.${{ cxx_compiler_version }}
+  # abi_version: 1.${{ nanobind_abi }}.${{ cxx_compiler_version }}
+  abi_version: 0.${{ nanobind }}.${{ cxx_compiler_version }}
 
 recipe:
   name: ${{ name|lower }}-meta
@@ -60,13 +61,13 @@ outputs:
             - python
             - cross-python_${{ target_platform }}
             - nanobind
-            - nanobind-abi
+            # - nanobind-abi
       host:
         - scikit-build-core
         - python
         - pip
         - nanobind
-        - nanobind-abi
+        # - nanobind-abi
         - ${{ pin_subpackage('fenics-libbasix', exact=True) }}
       run:
         - python
@@ -107,7 +108,8 @@ outputs:
         strong:
           - fenics-basix-nanobind-abi ==${{ abi_version }}
       run_constraints:
-        - nanobind-abi ${{ nanobind_abi }}.*
+        - nanobind ${{ nanobind }}.*
+        # - nanobind-abi ${{ nanobind_abi }}.*
         # confine to nanobind builds with nanobind_abi constraints
         - nanobind >=2.4
         - if: not win


### PR DESCRIPTION
v1 isn't ready yet because the nanobind-abi package has some problems, so keep the stricter pinning for now