### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,7 +18,7 @@ recipe:
 
 source:
   url: https://github.com/fenics/basix/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 2e168b2a27be6f71d0a19ef4c1c8f6cae5d52b8034f01a22ae03e80afb60eede
+  sha256: b93221dac7d3fea8c10e77617f6201036de35d0c5437440b718de69a28c3773f
 
 build:
   number: 1


### PR DESCRIPTION
Convert scalar `lib:` values in package_contents to lists. For example `lib: basix` becomes `lib:\n  - basix`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
